### PR TITLE
Remove unnecessary relative import

### DIFF
--- a/gommap_win_test.go
+++ b/gommap_win_test.go
@@ -7,7 +7,6 @@ import (
 	"syscall"
 	"testing"
 
-	"./gommap"
 	. "gopkg.in/check.v1"
 )
 


### PR DESCRIPTION
This fixes issues with [dep](https://github.com/golang/dep) which [Liftbridge](https://github.com/liftbridge-io/liftbridge) still uses.