### PR TITLE
Add FreeBSD support

### DIFF
--- a/gommap_test.go
+++ b/gommap_test.go
@@ -4,11 +4,12 @@ package gommap
 
 import (
 	"io/ioutil"
-	. "launchpad.net/gocheck"
 	"os"
 	"path"
 	"syscall"
 	"testing"
+
+	. "launchpad.net/gocheck"
 )
 
 func TestAll(t *testing.T) {
@@ -149,32 +150,4 @@ func (s *S) TestIsResidentUnderOnePage(c *C) {
 	mapped, err := mmap.IsResident()
 	c.Assert(err, IsNil)
 	c.Assert(mapped, DeepEquals, []bool{true})
-}
-
-func (s *S) TestIsResidentTwoPages(c *C) {
-	testPath := path.Join(c.MkDir(), "test.txt")
-	file, err := os.Create(testPath)
-	c.Assert(err, IsNil)
-	defer file.Close()
-
-	file.Seek(int64(os.Getpagesize()*2-1), 0)
-	file.Write([]byte{'x'})
-
-	mmap, err := Map(file.Fd(), PROT_READ|PROT_WRITE, MAP_PRIVATE)
-	c.Assert(err, IsNil)
-	defer mmap.UnsafeUnmap()
-
-	// Not entirely a stable test, but should usually work.
-
-	mmap[len(mmap)-1] = 'x'
-
-	mapped, err := mmap.IsResident()
-	c.Assert(err, IsNil)
-	c.Assert(mapped, DeepEquals, []bool{false, true})
-
-	mmap[0] = 'x'
-
-	mapped, err = mmap.IsResident()
-	c.Assert(err, IsNil)
-	c.Assert(mapped, DeepEquals, []bool{true, true})
 }

--- a/gommap_twopage_test.go
+++ b/gommap_twopage_test.go
@@ -1,0 +1,38 @@
+// +build !windows,!freebsd
+
+package gommap
+
+import (
+	"os"
+	"path"
+
+	. "launchpad.net/gocheck"
+)
+
+func (s *S) TestIsResidentTwoPages(c *C) {
+	testPath := path.Join(c.MkDir(), "test.txt")
+	file, err := os.Create(testPath)
+	c.Assert(err, IsNil)
+	defer file.Close()
+
+	file.Seek(int64(os.Getpagesize()*2-1), 0)
+	file.Write([]byte{'x'})
+
+	mmap, err := Map(file.Fd(), PROT_READ|PROT_WRITE, MAP_PRIVATE)
+	c.Assert(err, IsNil)
+	defer mmap.UnsafeUnmap()
+
+	// Not entirely a stable test, but should usually work.
+
+	mmap[len(mmap)-1] = 'x'
+
+	mapped, err := mmap.IsResident()
+	c.Assert(err, IsNil)
+	c.Assert(mapped, DeepEquals, []bool{false, true})
+
+	mmap[0] = 'x'
+
+	mapped, err = mmap.IsResident()
+	c.Assert(err, IsNil)
+	c.Assert(mapped, DeepEquals, []bool{true, true})
+}

--- a/mmap_unix.go
+++ b/mmap_unix.go
@@ -1,3 +1,6 @@
+// +build linux freebsd
+// +build 386
+
 package gommap
 
 import "syscall"

--- a/mmap_unix64.go
+++ b/mmap_unix64.go
@@ -1,3 +1,6 @@
+// +build linux freebsd
+// +build amd64 arm64
+
 package gommap
 
 import "syscall"


### PR DESCRIPTION
Consolidate Linux and FreeBSD support into the same files using build tags.

The semantics for mincore are different on FreeBSD than for Linux (based on the value of vm.mincore_mapped, mincore reports mappings, not residency). So cut out the TestIsResidentTwoPages for FreeBSD but continue using it on Linux.

gofmt moved the import line in the test file.